### PR TITLE
fix(eslint-config): Disabled linebreak-style rule in ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,7 +28,7 @@ export default [
       indent: ['warn', 2],
       'no-extra-parens': 'warn',
       'no-nested-ternary': 'error',
-      'linebreak-style': ['error', 'unix'],
+      'linebreak-style': 'off',
       'no-cond-assign': ['error', 'always'],
       'no-console': 'error',
       '@typescript-eslint/sort-type-constituents': 'error',


### PR DESCRIPTION
Deshabilite la regla linebreak-style porque en Windows tira muchísimos errores por utilizar CRLF en vez de LF ya que por default los archivos en Windows se crean con esa configuración.

Antes:

<img width="660" height="101" alt="image" src="https://github.com/user-attachments/assets/794e4f09-5f95-463a-adc1-68a686a2a633" />

Despues:

<img width="270" height="106" alt="image" src="https://github.com/user-attachments/assets/b7e46f54-e044-4697-8ac3-d7edb0f6fcf8" />
