### PR TITLE
fix(eslint-config): Add svelte.ts files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,7 @@ export default [
     },
   },
   {
-    files: ['**/*.svelte'],
+    files: ['**/*.svelte', '**/*.svelte.ts'],
     languageOptions: {
       parser: svelteParser,
       parserOptions: {


### PR DESCRIPTION
Modifico el `eslint.config.js` para que tenga en cuenta los archivos `.svelte.ts`. Sin este cambio el linter no valida bien esos archivos.

Justo en este ejemplo no hay ningún archivo que sea `.svelte.ts` pero como estamos usando este ejemplo de referencia para el setup del entorno me parece bien agregarlo así después no tienen ningún problema.

@fdodino