### PR TITLE
Fix: agrego svelte a "eslint.validate" en settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,8 @@
     "eslint.validate": [
         "javascript",
         "javascriptreact",
-        "typescript"
+        "typescript",
+        "svelte"
     ],
     "[svelte]": {
         "editor.defaultFormatter": "svelte.svelte-vscode"


### PR DESCRIPTION
Para que el linter valide los archivos `.svelte`.

@fdodino 