### PR TITLE
Fix: estado compartido de toasts en el servidor

### DIFF
--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,4 +1,3 @@
-import { showError } from '$lib/domain/errorHandler'
 import { tareaService } from '$lib/services/tareaService'
 
 export const load = async ({ depends }) => {
@@ -7,7 +6,6 @@ export const load = async ({ depends }) => {
     const tareas = await tareaService.todasLasTareas()
     return { tareas }
   } catch (error) {
-    showError('Conexión al servidor', error)
-    return { tareas: [] }
+    return { tareas: [], error }
   }
 }

--- a/src/routes/loadTasks.spec.ts
+++ b/src/routes/loadTasks.spec.ts
@@ -8,7 +8,6 @@ vi.mock('$lib/domain/errorHandler', () => ({
 
 vi.mock('axios')
 
-import { showError } from '$lib/domain/errorHandler'
 import { Tarea } from '$lib/domain/tarea'
 import { Usuario } from '$lib/domain/usuario'
 import axios from 'axios'
@@ -36,9 +35,9 @@ describe('+page.ts load', () => {
     const err = new Error('network')
     vi.mocked(axios.get).mockRejectedValue(err)
 
-    const { tareas } = await load({depends: vi.fn(), params:{}} as unknown as Parameters<typeof load>[0])
+    const { tareas, error } = await load({depends: vi.fn(), params:{}} as unknown as Parameters<typeof load>[0])
 
-    expect(showError).toHaveBeenCalledWith('Conexión al servidor', err)
     expect(tareas).toEqual([])
+    expect(error).toEqual(err)
   })
 })


### PR DESCRIPTION
Hola!. Perdón que caiga tarde con esto.

https://github.com/uqbar-project/eg-tareas-svelte/blob/37b0730aeeef2bb653d583af1fb46ffbac53119e/src/routes/%2Bpage.ts#L4-L13

Creo que llamar al toast en la función load no es la mejor idea porque SvelteKit por defecto renderiza la primera vez en el servidor entonces el estado del store de toasts se está guardando en el server (que es el mismo para todos los usuarios).  

Esto no es lo óptimo porque:
- Se supone que el server tiene que ser stateless.
- Los toasts se están acumulando en el server. No se llega a notar tanto porque rápidamente renderiza por segunda vez en el cliente y se corrige sólo (y además se van autoeliminado con un timeout). Pero el problema existe, acá dejo un video donde se ve como los toasts se mantienen al refrescar la página (les saqué el timeout para que se pueda apreciar mejor el problema):

https://github.com/user-attachments/assets/c8324e78-83b1-408d-a9ea-b4b23c70e260

y lo peor es que si entra otro usuario a la página (en este caso una ventana de incógnito) va a ver los toasts de otros usuarios:

<img width="2160" height="1186" alt="image" src="https://github.com/user-attachments/assets/10f461f7-3059-4df7-b816-a730460971f7" />

La solución que implementé en este PR es manejar los toasts sólamente del lado del cliente. Otra forma de solucionarlo sería deshabilitar el SSR.

no sé como la ven @fdodino @Juancete